### PR TITLE
Add a required config key that was missing from the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,11 @@ module.exports = function(config) {
     envPreprocessor: [
       'PATH',
       'HOME'
-    ]
+    ],
+
+    plugins: [
+      'karma-env-preprocessor'
+    ],
   });
 };
 ```

--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ You can simple do it by:
 npm install karma-env-preprocessor --save-dev
 ```
 
+To load `karma-env-preprocessor` into Karma you should add it to the plugins array in the Karma configuration file.
+For more information see [the Plugins section](http://karma-runner.github.io/0.13/config/plugins.html) of the Karma documentation.
+
 ## Configuration
 Any files you preprocess using this plugin will be affected, e.g for all JavaScript files:
 ```js


### PR DESCRIPTION
- When I tried out this plugin, I couldn't get it to work
- Turns out that I just needed to add it as a plugin
- It is probably obvious to someone who is experienced with Karma but it tripped me up a bit
- Its a simple change but I think a useful one
